### PR TITLE
Adding test config

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "main": "eslint.json",
   "files": [
     "LICENSE",
-    "eslint.json"
+    "eslint.json",
+    "test.json"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/test.json
+++ b/test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./eslint.json",
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "max-len": 0
+  }
+}


### PR DESCRIPTION
This should let us use the following:

``` json
{
  "extends": "gulp/test"
}
```

... which will enable the "mocha" `env` and disables the `max-len` rule.

Fixes #2 
