### PR TITLE
Set root: true

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -1,4 +1,5 @@
 {
+  "root": true,
   "env": {
     "node": true
   },


### PR DESCRIPTION
Default to setting `root: true` to stop eslint looking for config files in parent directories.

This came up in the CitGM CI, as we happened to have a `.eslintrc` file in a parent directory. We've resolved that issue now, but this seems like a sensible default (if you want to implicitly inherit from parent config files you'll probably know to overwrite this).

If this doesn't make sense for gulp then feel free to close!

Fixes: https://github.com/nodejs/citgm/issues/399