### PR TITLE
Update for eslint@>2.x

### DIFF
--- a/eslint.json
+++ b/eslint.json
@@ -11,6 +11,7 @@
     "curly": 2,
     "eol-last": 2,
     "eqeqeq": [2, "smart"],
+    "keyword-spacing": 2,
     "max-depth": [1, 3],
     "max-len": [1, 80],
     "max-statements": [1, 30],
@@ -23,7 +24,6 @@
     "object-curly-spacing": [2, "always"],
     "quotes": [2, "single", "avoid-escape"],
     "semi": [2, "always"],
-    "space-after-keywords": [2, "always"],
     "space-unary-ops": 2
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,5 @@
     "eslint",
     "eslint-config",
     "eslint config"
-  ],
-  "peerDependencies": {
-    "eslint": "^2.13.1"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "eslint",
     "eslint-config",
     "eslint config"
-  ]
+  ],
+  "peerDependencies": {
+    "eslint": "^2.13.1"
+  }
 }


### PR DESCRIPTION
Replace space-after-keywords with keyword-spacing
Adds eslint as a peer dependency

fixes #10
